### PR TITLE
Ignore E402 error when running flake8 linter

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -31,7 +31,7 @@ commands =
 	coveralls
 
 [flake8]
-ignore = E126, E127, E128
+ignore = E126, E127, E128, E402
 
 [testenv:flake8]
 basepython = python2.7


### PR DESCRIPTION
(i.e. E402 module level import not at top of file)