### PR TITLE
Drop coveralls usage

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,3 +1,2 @@
 coverage==4.0.3
-coveralls==1.1
 flake8==2.5.1

--- a/tox.ini
+++ b/tox.ini
@@ -28,7 +28,6 @@ passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
 commands =
 	coverage run --source djlaterpay setup.py test
 	coverage report
-	coveralls
 
 [flake8]
 ignore = E126, E127, E128


### PR DESCRIPTION
Lets drop the library / service dependency in favour of getting to 100%
coverage and using `fail_under`